### PR TITLE
Fix CI: escape $fpath variable in shell completion script

### DIFF
--- a/.github/workflows/update-claude-cli-docs.yml
+++ b/.github/workflows/update-claude-cli-docs.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - fixci  # Temporary for testing
     paths:
       - 'scripts/generate_claude_cli_docs.sh'
       - 'scripts/generate_claude_cli_completions.sh'

--- a/.github/workflows/update-claude-cli-docs.yml
+++ b/.github/workflows/update-claude-cli-docs.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - fixci  # Temporary for testing
     paths:
       - 'scripts/generate_claude_cli_docs.sh'
       - 'scripts/generate_claude_cli_completions.sh'

--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,63 @@
+# Claude CLI Shell Completions
+
+This directory contains shell completion files for the Claude CLI.
+
+## Installation
+
+### Bash
+
+Add the following line to your `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+source /path/to/claude.bash
+```
+
+Or copy the file to the bash completions directory:
+
+```bash
+sudo cp claude.bash /etc/bash_completion.d/
+```
+
+### Zsh
+
+Copy the completion file to a directory in your `$fpath`:
+
+```bash
+# For user installation
+mkdir -p ~/.zsh/completions
+cp _claude ~/.zsh/completions/
+
+# Add to ~/.zshrc if not already present
+echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+```
+
+Or for system-wide installation:
+
+```bash
+sudo cp _claude /usr/local/share/zsh/site-functions/
+```
+
+### Fish
+
+Copy the completion file to the fish completions directory:
+
+```bash
+# For user installation
+cp claude.fish ~/.config/fish/completions/
+
+# Or for system-wide installation
+sudo cp claude.fish /usr/share/fish/vendor_completions.d/
+```
+
+## Regenerating Completions
+
+To regenerate these completion files, run:
+
+```bash
+./scripts/generate_claude_cli_completions.sh
+```
+
+---
+
+*These completions are automatically generated. For the latest Claude CLI features, regenerate the completions after updating Claude CLI.*

--- a/docs/claude_cli_reference.md
+++ b/docs/claude_cli_reference.md
@@ -2,8 +2,8 @@
 
 This document provides a comprehensive overview of all Claude CLI commands and their options.
 
-Generated on: 2025-07-23 00:20:13 UTC
-Claude CLI Version: 1.0.58 (Claude Code)
+Generated on: 2025-07-24 07:17:13 UTC
+Claude CLI Version: 1.0.59 (Claude Code)
 
 ---
 

--- a/scripts/generate_claude_cli_completions.sh
+++ b/scripts/generate_claude_cli_completions.sh
@@ -313,7 +313,7 @@ mkdir -p ~/.zsh/completions
 cp _claude ~/.zsh/completions/
 
 # Add to ~/.zshrc if not already present
-echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+echo 'fpath=(~/.zsh/completions \$fpath)' >> ~/.zshrc
 echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
 \`\`\`
 


### PR DESCRIPTION
## Summary
- Fixed the failing GitHub Actions workflow for documentation updates
- Escaped the `$fpath` variable in the shell completion generation script

## Problem
The scheduled CI job was failing with an "unbound variable" error when generating shell completions. The `$fpath` variable in a heredoc was being evaluated at script runtime rather than being written literally to the output file.

## Solution
Escaped the `$fpath` variable to `\$fpath` so it's written as-is to the README.md file instead of being evaluated.

## Test plan
- [x] Tested the script locally - runs successfully
- [ ] CI should pass after this fix is merged